### PR TITLE
better cli arg parsing

### DIFF
--- a/inc/mkn/kul/alloc/aligned.hpp
+++ b/inc/mkn/kul/alloc/aligned.hpp
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _MKN_KUL_ALLOC_ALIGNED_HPP_
 #define _MKN_KUL_ALLOC_ALIGNED_HPP_
 
+#include "mkn/kul/defs.hpp"
 #include "mkn/kul/alloc/base.hpp"
 
 #include <new>

--- a/inc/mkn/kul/src/cli/asArgs.ipp
+++ b/inc/mkn/kul/src/cli/asArgs.ipp
@@ -38,7 +38,7 @@ std::size_t sub_string_to_next_occurrence(std::string const& cmd, std::size_t co
   auto const pos = rest.find(needle);
   if (pos == std::string::npos)
     KEXCEPT(mkn::kul::Exception, "Error: CLI Arg parsing unclosed quotes!");
-  return pos;
+  return pos + s;
 }
 
 }  // namespace
@@ -57,10 +57,8 @@ void mkn::kul::cli::asArgs(std::string const& cmd, std::vector<std::string>& arg
 
     } else if (openQuotesD) {
       auto const pos = sub_string_to_next_occurrence(cmd, i, "\"");
-      arg = cmd.substr(i, pos);
-      if (arg.size() > 0) args.push_back(arg);
-      i += arg.size();
-      arg.clear();
+      arg += cmd.substr(i, pos - i);
+      i = pos;
       openQuotesD = false;
       continue;
     }

--- a/tst/test/cli.cpp
+++ b/tst/test/cli.cpp
@@ -13,3 +13,12 @@ TEST(CLI_Test, ParseCommandLineArguments) {
   EXPECT_EQ("words not in quotes", v[2]);
   EXPECT_EQ("end", v[3]);
 }
+
+TEST(CLI_Test, ParseCommandPythonExample) {
+  std::vector<std::string> v =
+      mkn::kul::cli::asArgs("python3 -c \"import sys; print('lol ' + dir(sys)\"");
+  ASSERT_EQ(3ull, v.size());
+  EXPECT_EQ("python3", v[0]);
+  EXPECT_EQ("-c", v[1]);
+  EXPECT_EQ("import sys; print('lol ' + dir(sys)", v[2]);
+}

--- a/tst/test/cli.cpp
+++ b/tst/test/cli.cpp
@@ -22,3 +22,11 @@ TEST(CLI_Test, ParseCommandPythonExample) {
   EXPECT_EQ("-c", v[1]);
   EXPECT_EQ("import sys; print('lol ' + dir(sys)", v[2]);
 }
+
+TEST(CLI_Test, ParseWeirdPythonExample) {
+  std::vector<std::string> v = mkn::kul::cli::asArgs("python3 -c lol\"import sys\"lol");
+  ASSERT_EQ(3ull, v.size());
+  EXPECT_EQ("python3", v[0]);
+  EXPECT_EQ("-c", v[1]);
+  EXPECT_EQ("lolimport syslol", v[2]);
+}

--- a/tst/test/cli.cpp
+++ b/tst/test/cli.cpp
@@ -6,10 +6,10 @@
 
 TEST(CLI_Test, ParseCommandLineArguments) {
   std::vector<std::string> v;
-  mkn::kul::cli::asArgs("/path/to \"words in quotes\" words\\ not\\ in\\ quotes end", v);
-  EXPECT_EQ((size_t)4, v.size());
+  mkn::kul::cli::asArgs("/path/to \"words 'in' quotes\" words\\ not\\ in\\ quotes end", v);
+  ASSERT_EQ(4ull, v.size());
   EXPECT_EQ("/path/to", v[0]);
-  EXPECT_EQ("words in quotes", v[1]);
+  EXPECT_EQ("words 'in' quotes", v[1]);
   EXPECT_EQ("words not in quotes", v[2]);
   EXPECT_EQ("end", v[3]);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line argument parsing to better handle quoted segments, embedded single quotes inside double quotes, and escaped spaces.

* **Tests**
  * Updated existing tests for embedded single quotes and tightened an assertion; added tests covering Python -c parsing and an odd/malformed Python example.

* **Chores**
  * Minor header include adjustment (no public APIs changed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->