### PR TITLE
default proc polling

### DIFF
--- a/inc/mkn/kul/os/nixish/src/proc/run.ipp
+++ b/inc/mkn/kul/os/nixish/src/proc/run.ipp
@@ -30,6 +30,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 // IWYU pragma: private, include "mkn/kul/proc.hpp"
 
+#ifndef _MKN_KUL_PROC_LOOP_NSLEEP_
+#error  // define as 0 to disable
+#endif
+
 void mkn::kul::Process::run() KTHROW(mkn::kul::proc::Exception) {
   {
     int16_t ret = 0;
@@ -66,14 +70,14 @@ void mkn::kul::Process::run() KTHROW(mkn::kul::proc::Exception) {
       char cOut[30024] = {'\0'};
       char cErr[30024] = {'\0'};
       do {
-#if defined(_MKN_KUL_PROC_LOOP_NSLEEP_) && (_MKN_KUL_PROC_LOOP_NSLEEP_ > 0)
+#if _MKN_KUL_PROC_LOOP_NSLEEP_
         mkn::kul::this_thread::nSleep(_MKN_KUL_PROC_LOOP_NSLEEP_);
 #endif
         alive = ::kill(pid(), 0) == 0;
         if (FD_ISSET(popPip[1], &childOutFds)) {
           bool b = 0;
           do {
-#if defined(_MKN_KUL_PROC_LOOP_NSLEEP_) && (_MKN_KUL_PROC_LOOP_NSLEEP_ > 0)
+#if _MKN_KUL_PROC_LOOP_NSLEEP_
             mkn::kul::this_thread::nSleep(_MKN_KUL_PROC_LOOP_NSLEEP_);
 #endif
 
@@ -93,7 +97,7 @@ void mkn::kul::Process::run() KTHROW(mkn::kul::proc::Exception) {
         if (FD_ISSET(popPip[2], &childOutFds)) {
           bool b = 0;
           do {
-#if defined(_MKN_KUL_PROC_LOOP_NSLEEP_) && (_MKN_KUL_PROC_LOOP_NSLEEP_ > 0)
+#if _MKN_KUL_PROC_LOOP_NSLEEP_
             mkn::kul::this_thread::nSleep(_MKN_KUL_PROC_LOOP_NSLEEP_);
 #endif
 

--- a/inc/mkn/kul/os/win/src/proc/run.cpp
+++ b/inc/mkn/kul/os/win/src/proc/run.cpp
@@ -29,6 +29,10 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifndef _MKN_KUL_PROC_LOOP_NSLEEP_
+#error  // define as 0 to disable
+#endif
+
 // This file is included by other files and is not in itself syntactically
 // correct.
 
@@ -166,7 +170,7 @@ if (this->waitForExit()) {
   bSuccess = FALSE;
   bool alive = true;
   do {
-#if defined(_MKN_KUL_PROC_LOOP_NSLEEP_) && (_MKN_KUL_PROC_LOOP_NSLEEP_ > 0)
+#if _MKN_KUL_PROC_LOOP_NSLEEP_
     mkn::kul::this_thread::nSleep(_MKN_KUL_PROC_LOOP_NSLEEP_);
 #endif
     alive = WaitForSingleObject(piProcInfo.hProcess, 11) == WAIT_TIMEOUT;

--- a/inc/mkn/kul/proc.hpp
+++ b/inc/mkn/kul/proc.hpp
@@ -31,6 +31,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _MKN_KUL_PROC_HPP_
 #define _MKN_KUL_PROC_HPP_
 
+#ifndef _MKN_KUL_PROC_LOOP_NSLEEP_
+#define _MKN_KUL_PROC_LOOP_NSLEEP_ 1000000
+#endif /* _MKN_KUL_PROC_LOOP_NSLEEP_ */
+
 #include "mkn/kul/os.hpp"
 #include "mkn/kul/cli.hpp"
 #include "mkn/kul/log.hpp"  // IWYU pragma: keep


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified process loop sleep control logic across Unix and Windows implementations.

* **Chores**
  * Introduced configurable preprocessor macro for process loop timing behavior (defaults to 1000000).
  * Added compile-time validation to ensure required macro configuration is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->